### PR TITLE
📝 docs(mkdocs.yml): add Google Analytics tracking and cookie consent configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,3 +22,17 @@ extra_javascript:
 
 extra_css:
   - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/katex.min.css
+
+extra:
+  analytics:
+    provider: google
+    property: G-XZ7G2PVPYR
+  consent:
+    title: Cookie consent
+    description: >-
+      I use cookies on this site to enhance your user experience, measure the effectiveness of my 
+      blog, and optimize your search results. By clicking 'Accept', you consent to the use of cookies 
+      and help me to improve my blog. Thank you!
+    actions:
+      - accept
+      - reject


### PR DESCRIPTION
…configuration

The changes in this commit add configuration for Google Analytics tracking and cookie consent to the `mkdocs.yml` file.

- Added `extra.analytics` section with `provider` set to "google" and `property` set to "G-XZ7G2PVPYR" to enable Google Analytics tracking on the site.
- Added `extra.consent` section with `title`, `description`, and `actions` to configure the cookie consent banner. The `title` is set to "Cookie consent", the `description` provides information about the use of cookies on the site and the purpose, and the `actions` array contains "accept" and "reject" options for users to choose from.